### PR TITLE
ENG-26714: add mask to MatchNxCtState

### DIFF
--- a/ofputil/match_nicira.go
+++ b/ofputil/match_nicira.go
@@ -21,6 +21,6 @@ func MatchNxConjID(id uint32) ofp.XM {
 	return nicira(ofp.NXMTypeConjID, bytesOf(id), nil)
 }
 
-func MatchNxCtState(state uint32) ofp.XM {
-	return nicira(ofp.NXMTypeCtState, bytesOf(state), nil)
+func MatchNxCtState(state, mask uint32) ofp.XM {
+	return nicira(ofp.NXMTypeCtState, bytesOf(state), bytesOf(mask))
 }


### PR DESCRIPTION
I'm adding the mask to the ctStateMatch. 

From my experiment, bitwise or the fields together in the current implementation does not track all states....

it seems like the match have following pattern:
- if the mask is 0, do not check the field
- if the mask is 1, and state is 1 on the same bit, match the packet with that tag. For example +new
- if the mask is 1, and state is 0 on the same bit, match the packet without that tag. for example -new
